### PR TITLE
Add support for compiling a string

### DIFF
--- a/rv/addons/lib/XEH_pre_init.sqf
+++ b/rv/addons/lib/XEH_pre_init.sqf
@@ -92,6 +92,17 @@ carma2_fnc_compile = {
     _result;
 };
 
+carma2_fnc_compileStr = {
+    params ["_string", ["_execute", true]];
+    private _text = "1" + _string;
+
+    private _result = (compile preprocessFileLineNumbers ("carma_dll" callExtension _text));
+    if (_execute) then {
+        [] call _result;
+    };
+    _result;
+};
+
 carma2_fnc_spawnWrapper = {
     [_this, "carma2_fnc_spawnWrapperInternal"] call carma2_fnc_callCritical;
 };

--- a/rv/addons/lib/carma.hpp
+++ b/rv/addons/lib/carma.hpp
@@ -1,9 +1,10 @@
 //carma.hpp
 
 #define CARMA_COMPILE(file) [file, true] call carma2_fnc_compile
+#define CARMA_STRCOMPILE(string) [string, true] call carma2_fnc_compileStr
 #define IS_CARMAOBJECT(var) (typeName var == "LOCATION" && {(text var) == "carma2_obj"})
 
-#define CRITICAL_PARAMS   params ["_counter"]; (carma2_criticalArgs select _counter) params 
+#define CRITICAL_PARAMS   params ["_counter"]; (carma2_criticalArgs select _counter) params
 #define CRITICAL_SETRETURN(val) carma2_criticalArgs set[_counter, val]
 
 #define carma2_start_crit_section ____carma_crit_section = {


### PR DESCRIPTION
Adds a macro and function to compile Carma code outside of a file / string only.

Would be useful for writing a carma version of the debug console or executing carma code from other sources.
