### PR TITLE
Fix number being treated as variable

### DIFF
--- a/src/compiler/compiler.cpp
+++ b/src/compiler/compiler.cpp
@@ -3,6 +3,7 @@
 #include <unordered_map>
 #include <sstream>
 #include <iostream>
+#include <ctype.h>
 
 namespace carma {
 	namespace compiler {
@@ -254,6 +255,9 @@ namespace carma {
 					std::next(current_token)->val == "{" 
 					)) {
 					if (std::next(current_token)->val == "." || std::next(current_token)->val == "::") {
+                        if (isNumber(current_token->val))
+                            continue;
+
 						auto object_token = current_token;
 						auto dot_token = std::next(current_token);
 						auto member_token = std::next(current_token, 2);
@@ -728,5 +732,12 @@ namespace carma {
 
 			return minimized_tokens;
 		}
+
+        bool isNumber(const std::string& input) {
+            if (input.length() > 0) {
+                return isdigit(input[0]);
+            }
+            return true;
+        }
 	}
 };

--- a/src/compiler/compiler.hpp
+++ b/src/compiler/compiler.hpp
@@ -15,5 +15,7 @@ namespace carma {
 		std::string build_string(const token_list &tokens_, const token_entry start_entry_, const token_entry end_entry_);
 		std::string build_string_pretty(const token_list &tokens_, const token_entry start_entry_, const token_entry end_entry_);
 		token_list minimize(const token_list &tokens_, const token_entry start_entry_, const token_entry end_entry_);
+
+        bool isNumber(const std::string& input);
 	};
 };


### PR DESCRIPTION
Closes #7
Using the . operator on a float would be compiled as a var.var. This will instead ignore the token in the compiler if the first character is a number. This is also invalid in regular sqf and will throw a script error.
